### PR TITLE
cloudbuild: update protoc version to v3.15.0

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -80,7 +80,7 @@ steps:
       - protoc-debug
 
 substitutions:
-  _PROTOC_VERSION: "3.14.0"
+  _PROTOC_VERSION: "3.15.0"
   _GOLANG_VERSION: "1.16"
   _ALPINE_VERSION: "3.13"
   _PROTOC_GEN_GO_VERSION: "v1.25.0"


### PR DESCRIPTION
cloudbuild: update protoc version to v3.15.0.

- https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.0