### PR TITLE
cloudbuild: update protoc version to v3.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Supported:
 - [v3.13.0](https://github.com/protocolbuffers/protobuf/releases/v3.13.0)
 - [v3.14.0](https://github.com/protocolbuffers/protobuf/releases/v3.14.0)
 - [v3.15.0](https://github.com/protocolbuffers/protobuf/releases/v3.15.0)
+- [v3.15.1](https://github.com/protocolbuffers/protobuf/releases/v3.15.1)
 
 See also [protocolbuffers/protobuf/releases][protocolbuffers/protobuf/releases].
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -80,7 +80,7 @@ steps:
       - protoc-debug
 
 substitutions:
-  _PROTOC_VERSION: "3.15.0"
+  _PROTOC_VERSION: "3.15.1"
   _GOLANG_VERSION: "1.16"
   _ALPINE_VERSION: "3.13"
   _PROTOC_GEN_GO_VERSION: "v1.25.0"


### PR DESCRIPTION
cloudbuild: update protoc version to v3.15.1.

- https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.1