### PR TITLE
cloudbuild: update protoc version to v3.15.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Supported:
 - [v3.15.4](https://github.com/protocolbuffers/protobuf/releases/v3.15.4)
 - [v3.15.5](https://github.com/protocolbuffers/protobuf/releases/v3.15.5)
 - [v3.15.6](https://github.com/protocolbuffers/protobuf/releases/v3.15.6)
+- [v3.15.7](https://github.com/protocolbuffers/protobuf/releases/v3.15.7)
 
 See also [protocolbuffers/protobuf/releases][protocolbuffers/protobuf/releases].
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -84,7 +84,7 @@ steps:
       - protoc-debug
 
 substitutions:
-  _PROTOC_VERSION: "3.15.6"
+  _PROTOC_VERSION: "3.15.7"
   _GOLANG_VERSION: "1.16"
   _ALPINE_VERSION: "3.13"
   _PROTOC_GEN_GO_VERSION: "v1.25.0"


### PR DESCRIPTION
cloudbuild: update protoc version to v3.15.7.

- https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.7