### PR TITLE
cloudbuild: update protoc-gen-go-grpc to v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ protoc binary with Go protoc plugins container images.
 #### Go protoc plugins
 
 - [google.golang.org/protobuf/cmd/protoc-gen-go@v1.26.0](https://github.com/protocolbuffers/protobuf-go/tree/v1.26.0)
-- [google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.0.1](https://github.com/grpc/grpc-go/tree/cmd/protoc-gen-go-grpc/v1.0.1/cmd/protoc-gen-go-grpc)
+- [google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0](https://github.com/grpc/grpc-go/tree/cmd/protoc-gen-go-grpc/v1.1.0/cmd/protoc-gen-go-grpc)
 
 
 <!-- links -->

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -88,7 +88,7 @@ substitutions:
   _GOLANG_VERSION: "1.16"
   _ALPINE_VERSION: "3.13"
   _PROTOC_GEN_GO_VERSION: "v1.26.0"
-  _PROTOC_GEN_GO_GRPC_VERSION: "v1.0.1"
+  _PROTOC_GEN_GO_GRPC_VERSION: "v1.1.0"
 
 tags:
   - "protoc.protoc"


### PR DESCRIPTION
cloudbuild: update protoc-gen-go-grpc to v1.1.0.

- https://github.com/grpc/grpc-go/releases/tag/cmd/protoc-gen-go-grpc/v1.1.0